### PR TITLE
Fix menu bar logo after youtube update.

### DIFF
--- a/RosePineYoutube.user.css
+++ b/RosePineYoutube.user.css
@@ -247,6 +247,19 @@
 	{
 		fill: var(--main-color) !important;
 	}
+
+    
+    /* top bar icon fix */
+    
+    yt-icon#logo-icon .external-icon > svg > g:nth-child(1) path:nth-child(1) {
+        fill: var(--main-color) !important;
+    }
+    
+    yt-icon#logo-icon .external-icon > svg g:nth-child(2) {
+        fill: var(--main-text) !important;
+    }
+    
+    
 	#logo-icon-container.ytd-topbar-logo-renderer #youtube-paths.ytd-topbar-logo-renderer path.ytd-topbar-logo-renderer,
 	#youtube-red-paths /*premium*/
 	{
@@ -1703,9 +1716,6 @@
 		border-bottom: 1px solid var(--main-color) !important;
 	}
 
-	/*New logo*/
-	#logo-icon-container.ytd-topbar-logo-renderer svg g path[fill*="#FF0000"],
-	ytd-topbar-logo-renderer.style-scope a svg > g > g:nth-child(1) > path:nth-child(1),
 	/*cookie version*/
 	svg.ytd-consent-bump-v2-lightbox > g:nth-child(1) > g:nth-child(1) > path:nth-child(1)
 	{

--- a/RosePineYoutube.user.css
+++ b/RosePineYoutube.user.css
@@ -2,7 +2,7 @@
 @name Rose Pine YouTube
 @namespace github.com/artilate/youtube
 @homepageURL https://github.com/artilate/youtube
-@version 1.3
+@version 1.3.1
 
 @updateURL https://github.com/artilate/youtube/raw/main/RosePineYoutube.user.css
 @description Soho vibes for YouTube

--- a/RosePineYoutube.user.css
+++ b/RosePineYoutube.user.css
@@ -248,6 +248,15 @@
 		fill: var(--main-color) !important;
 	}
 
+    /* video description fix */
+
+    ytd-text-inline-expander#description-inline-expander yt-attributed-string span span {
+        color: var(--main-text) !important;
+    }
+    
+    ytd-text-inline-expander#description-inline-expander yt-attributed-string span span a {
+        color: var(--main-color) !important;
+    }
     
     /* top bar icon fix */
     


### PR DESCRIPTION
I noticed that the Youtube logo in the top left wasn't being styled correctly anymore.
This remedies the problem, tested for both premium and non-premium.

Line 1706-1708 had to be removed because of the first letter being filled with "--main-color" after the update on the non-premium page.