### PR TITLE
fix: livechat hide button set to main background color

### DIFF
--- a/RosePineYoutube.user.css
+++ b/RosePineYoutube.user.css
@@ -2605,6 +2605,9 @@
 	{
 		background: var(--hover-background) !important;
 	}
+  .ytd-live-chat-frame {
+    background-color: var(--main-background) !important;
+  }
 	/*emoji*/
 	yt-formatted-string.yt-emoji-picker-category-renderer
 	{


### PR DESCRIPTION
When I watch a live chat it shows the dark theme background color and ignores the rose-pine colors.