### PR TITLE
Adds styling for Youtube Shorts titles

### DIFF
--- a/RosePineYoutube.user.css
+++ b/RosePineYoutube.user.css
@@ -871,7 +871,8 @@
 	#video-title.ytd-video-renderer,
 	h3.ytd-playlist-renderer,
 	#video-title.ytd-child-video-renderer, #length.ytd-child-video-renderer,
-	#video-title, #unplayableText, #length, #details
+	#video-title, #unplayableText, #length, #details,
+	.ShortsLockupViewModelHostEndpoint .yt-core-attributed-string--white-space-pre-wrap
 	{
 		color: var(--main-text) !important;
 	}


### PR DESCRIPTION
## Summary

Youtube shorts titles on the homepage don't have styling.

## Before

<img width="1120" alt="Screen Shot 2024-09-29 at 12 20 54 PM" src="https://github.com/user-attachments/assets/b1b038a1-4355-488c-8501-6ab648116a96">

## After

<img width="1120" alt="Screen Shot 2024-09-29 at 12 20 32 PM" src="https://github.com/user-attachments/assets/b778737e-75b5-46b3-a095-0b784494d4ac">

## Overview of Changes

* Added main text colour to shorts titles